### PR TITLE
feat: add reusable setup workflow for pnpm and Node.js

### DIFF
--- a/.github/workflows/reusable-setup.yml
+++ b/.github/workflows/reusable-setup.yml
@@ -1,0 +1,63 @@
+name: Setup pnpm & Node
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: 'Version spec of Node.js to use. Examples: 22, 22.x, lts/*, lts/iron. If omitted, falls back to node-version-file.'
+        required: false
+        type: string
+      node-version-file:
+        description: 'File containing the Node.js version to use (e.g. `.node-version`, `.nvmrc`). Used only when node-version is not set.'
+        required: false
+        type: string
+      pnpm-version:
+        description: 'Version of pnpm to use. Examples: 9, 10, latest. If omitted, reads from the packageManager field in package.json.'
+        required: false
+        type: string
+      operating-system:
+        description: The operating system to use (default `ubuntu-latest`)
+        required: false
+        default: ubuntu-latest
+        type: string
+      with-submodules:
+        description: Whether to include submodules when checking out the repository (default `false`)
+        required: false
+        default: 'false'
+        type: string
+      install-dependencies:
+        description: Whether to run `pnpm install` after setup (default `true`)
+        required: false
+        default: true
+        type: boolean
+      frozen-lockfile:
+        description: Whether to use `--frozen-lockfile` when installing dependencies (default `true`)
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  setup:
+    name: Setup
+    runs-on: ${{ inputs.operating-system }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: ${{ inputs.with-submodules }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ inputs.pnpm-version }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          node-version-file: ${{ inputs.node-version-file }}
+          cache: pnpm
+
+      - name: Install dependencies
+        if: ${{ inputs.install-dependencies == true }}
+        run: pnpm install${{ inputs.frozen-lockfile == true && ' --frozen-lockfile' || '' }}


### PR DESCRIPTION
## Summary

- Adds a new reusable workflow (`reusable-setup.yml`) for consistent pnpm + Node.js environment setup across all repos in the org
- `node-version` and `pnpm-version` are optional: if omitted, they fall back to `.node-version`/`.nvmrc` and the `packageManager` field in `package.json` respectively — matching the behavior of the underlying actions
- Supports `node-version-file` as an explicit alternative to `node-version`

## Inputs

| Input | Default | Description |
|---|---|---|
| `node-version` | — | Version spec (e.g. `22`, `22.x`, `lts/*`). Falls back to `node-version-file`. |
| `node-version-file` | — | File to read Node.js version from (`.node-version`, `.nvmrc`) |
| `pnpm-version` | — | pnpm version (e.g. `9`, `10`). Falls back to `packageManager` in `package.json`. |
| `operating-system` | `ubuntu-latest` | Runner OS |
| `with-submodules` | `false` | Include submodules in checkout |
| `install-dependencies` | `true` | Run `pnpm install` after setup |
| `frozen-lockfile` | `true` | Use `--frozen-lockfile` flag |

## Usage example

```yaml
jobs:
  setup:
    uses: wolfstar-project/.github/.github/workflows/reusable-setup.yml@main
    with:
      node-version: 22
      pnpm-version: 10
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
