### PR TITLE
fix(workflows): use native Blacksmith runners for multi-platform image builds

### DIFF
--- a/.github/workflows/reusable-publish-image.yml
+++ b/.github/workflows/reusable-publish-image.yml
@@ -15,7 +15,7 @@ on:
         required: false
         type: string
         description: 'The platforms to build the Docker image for (JSON array with platform and runner)'
-        default: '[{"platform": "linux/amd64", "runner": "ubuntu-latest"}, {"platform": "linux/arm64", "runner": "ubuntu-24.04-arm"}]'
+        default: '[{"platform": "linux/amd64", "runner": "blacksmith-4vcpu-ubuntu-2404"}, {"platform": "linux/arm64", "runner": "blacksmith-4vcpu-ubuntu-2404-arm"}]'
       tag:
         required: false
         type: string
@@ -51,7 +51,6 @@ jobs:
         include: ${{ fromJson(inputs.platforms) }}
     steps:
       - name: Prepare
-        if: ${{ inputs.enablePlatforms == true }}
         run: |
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
@@ -97,7 +96,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v7
         with:
-          name: digests-${{ strategy.job-index }}
+          name: digests-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1


### PR DESCRIPTION
## Cosa cambia

- I runner di default della matrix in `reusable-publish-image.yml` passano da `ubuntu-latest`/`ubuntu-24.04-arm` ai runner Blacksmith nativi per architettura (`blacksmith-4vcpu-ubuntu-2404` / `blacksmith-4vcpu-ubuntu-2404-arm`), completando la migrazione iniziata in #33: le action `useblacksmith/*` oggi vanno in fallback silenzioso sul builder locale quando girano su runner GitHub-hosted.
- Gli artifact dei digest sono nominati `digests-${{ env.PLATFORM_PAIR }}` come nell'esempio della [guida Docker multi-platform](https://docs.docker.com/build/building/multi-platform/); lo step `Prepare` ora gira sempre (prima era condizionato a `enablePlatforms` e la variabile restava inutilizzata).

## Contesto

Indagine sul problema "amd64 non pubblicato": il workflow pubblica correttamente entrambe le piattaforme (verificato sui run di wolfstar, staryl e publish-stable — l'index multi-arch viene creato e il tag commit-sha punta ancora ad esso). I tag `wolfstar:stable` e `staryl:latest` risultano però sovrascritti *dopo* la pubblicazione da un push esterno fatto da un docker engine su host arm64 (manifest Docker v2 singolo, senza attestazioni, stesso config blob dell'immagine arm64 di CI). Il fix di quel problema è fuori da questo repo; questa PR allinea comunque il workflow alla guida e ai runner nativi.

Seguono PR sui repo caller per rimuovere l'override `platforms` e usare i nuovi default nativi.

https://claude.ai/code/session_01Xv1EAagQkhuCRGY584Kuua

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/.github/pr/35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Observed that the native runners default platform mappings changed between the before and after runs, from linux/amd64 -\> ubuntu-latest and linux/arm64 -\> ubuntu-24.04-arm to linux/amd64 -\> blacksmith-4vcpu-ubuntu-2404 and linux/arm64 -\> blacksmith-4vcpu-ubuntu-2404-arm.
- Documented that the trex-artifacts/native-runners-validation-script.py was used as the executed parser for both runs.
- Compared the digest artifacts before and after, noting that the before state used base name digests-${{ strategy.job-index }} with a conditional Prepare, while the after state uses name: digests-${{ env.PLATFORM\_PAIR }} with Prepare unconditionally.
- Noted that the digest-artifacts-sim.py test harness was used to produce the before/after logs.

<a href="https://app.greptile.com/trex/runs/13117166/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Matrix as Build matrix
participant Runner as Blacksmith runner
participant Buildx as Blacksmith buildx
participant GHCR as GHCR
participant Artifacts as GitHub Artifacts
participant Merge as Merge job

Matrix->>Runner: Schedule linux/amd64 and linux/arm64 jobs
Runner->>Runner: Prepare PLATFORM_PAIR
Runner->>Buildx: Build and push image by digest
Buildx->>GHCR: Push platform-specific digest
Runner->>Artifacts: "Upload digests-${PLATFORM_PAIR}"
Merge->>Artifacts: "Download digests-*"
Merge->>GHCR: Create and push multi-platform manifest tags
Merge->>GHCR: Inspect published tag
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Matrix as Build matrix
participant Runner as Blacksmith runner
participant Buildx as Blacksmith buildx
participant GHCR as GHCR
participant Artifacts as GitHub Artifacts
participant Merge as Merge job

Matrix->>Runner: Schedule linux/amd64 and linux/arm64 jobs
Runner->>Runner: Prepare PLATFORM_PAIR
Runner->>Buildx: Build and push image by digest
Buildx->>GHCR: Push platform-specific digest
Runner->>Artifacts: "Upload digests-${PLATFORM_PAIR}"
Merge->>Artifacts: "Download digests-*"
Merge->>GHCR: Create and push multi-platform manifest tags
Merge->>GHCR: Inspect published tag
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(workflows): use native Blacksmith ru..."](https://github.com/wolfstar-project/.github/commit/46abab757c9e7a4bb51bf942bf8ee658d2681b91) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41485509)</sub>

<!-- /greptile_comment -->