### PR TITLE
fix(workflows): migrate Docker publish workflow from Blacksmith to Depot

### DIFF
--- a/.github/workflows/reusable-publish-image.yml
+++ b/.github/workflows/reusable-publish-image.yml
@@ -7,15 +7,15 @@ on:
         required: false
         type: string
         description: 'The image name to use for the Docker image'
-      enablePlatforms:
-        required: false
-        type: boolean
-        default: true
+      depotProject:
+        required: true
+        type: string
+        description: 'The Depot project ID to build this image with (see https://depot.dev)'
       platforms:
         required: false
         type: string
-        description: 'The platforms to build the Docker image for (JSON array with platform and runner)'
-        default: '[{"platform": "linux/amd64", "runner": "blacksmith-4vcpu-ubuntu-2404"}, {"platform": "linux/arm64", "runner": "blacksmith-4vcpu-ubuntu-2404-arm"}]'
+        description: 'Comma-separated platforms to build the Docker image for'
+        default: 'linux/amd64,linux/arm64'
       tag:
         required: false
         type: string
@@ -42,19 +42,13 @@ env:
   IMAGE_NAME: ${{ inputs.registryImage || github.repository }}
 
 jobs:
-  build:
-    name: Build ${{ matrix.platform }}
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(inputs.platforms) }}
+  build-and-push:
+    name: Build and push (multi-platform via Depot)
+    runs-on: depot-ubuntu-24.04-4
+    permissions:
+      contents: read
+      packages: write
     steps:
-      - name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-
       - name: Checkout repository
         uses: actions/checkout@v6
 
@@ -63,68 +57,13 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4.1.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push by digest
-        id: build
-        uses: useblacksmith/build-push-action@v2
-        with:
-          context: ${{ inputs.context }}
-          file: ${{ inputs.dockerFile }}
-          platforms: ${{ matrix.platform }}
-          labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v7
-        with:
-          name: digests-${{ env.PLATFORM_PAIR }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge:
-    name: Create and push manifest list
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: build
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@v8
-        with:
-          path: /tmp/digests
-          pattern: digests-*
-          merge-multiple: true
-
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=${{ inputs.tag }}
             type=raw,value=${{ inputs.commitHash || github.sha }}
 
+      - name: Set up Depot CLI
+        uses: depot/setup-action@v1
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4.1.0
         with:
@@ -132,12 +71,15 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
-
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.tag }}
+      - name: Build and push
+        uses: depot/build-push-action@v1
+        with:
+          project: ${{ inputs.depotProject }}
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerFile }}
+          platforms: ${{ inputs.platforms }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+        env:
+          DEPOT_TOKEN: ${{ secrets.DEPOT_TOKEN }}

--- a/.github/workflows/reusable-publish-image.yml
+++ b/.github/workflows/reusable-publish-image.yml
@@ -36,6 +36,10 @@ on:
         type: string
         default: ${{ github.sha }}
         description: 'The commit hash to use for the Docker image'
+    secrets:
+      DEPOT_TOKEN:
+        required: true
+        description: 'Depot API token used to authenticate the build (see https://depot.dev/docs/cli/authentication)'
 
 env:
   REGISTRY: ghcr.io

--- a/README.md
+++ b/README.md
@@ -137,7 +137,10 @@ jobs:
     uses: wolfstar-project/.github/.github/workflows/reusable-publish-image.yml@main
     with:
       registryImage: wolfstar-project/wolfstar
+      depotProject: your-depot-project-id
       tag: latest
+    secrets:
+      DEPOT_TOKEN: ${{ secrets.DEPOT_TOKEN }}
 ```
 
 </div>


### PR DESCRIPTION
## Summary
- Replace `useblacksmith/setup-docker-builder` + `useblacksmith/build-push-action` with `depot/setup-action` + `depot/build-push-action` in `reusable-publish-image.yml`.
- Depot builds each platform natively in a single job, so the per-platform matrix, QEMU setup, and the separate manifest-merge job are no longer needed — the workflow is now a single `build-and-push` job.
- The reusable workflow now requires a `depotProject` input; callers (wolfstar, ring, staryl) have been updated in their own PRs to pass their project ID.

## Test plan
- [ ] Confirm the Depot GitHub App is installed on the `wolfstar-project` org
- [ ] Confirm the `DEPOT_TOKEN` org/repo secret is set (confirmed available per user)
- [ ] Merge caller PRs (wolfstar #227, ring #94, staryl #57) after this one, and watch a Docker publish run end-to-end

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/.github/pr/41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until the credential-bearing Depot build action is pinned to an immutable commit.

The documented input and secret-contract issues are fixed, but `depot/build-push-action@v1` remains mutable while receiving the Depot token and running in a package-writing job.

**Files Needing Attention:** .github/workflows/reusable-publish-image.yml
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(workflows): declare DEPOT\_TOKEN secr..."](https://github.com/wolfstar-project/.github/commit/9044756afdba1bf277b014dcb23a3a5719d3d432) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47421688)</sub>

<!-- /greptile_comment -->