### PR TITLE
feat: add reusable documentation workflow

### DIFF
--- a/.github/workflows/reusable-documentation.yml
+++ b/.github/workflows/reusable-documentation.yml
@@ -121,6 +121,8 @@ jobs:
           PROJECT_NAME: ${{ inputs.project-name }}
           REF_NAME: ${{ needs.docgen.outputs.ref-name }}
           SOURCE_SHA: ${{ github.sha }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           if [[ ! "$REF_NAME" =~ ^[A-Za-z0-9._-]+$ ]]; then
             echo "Refusing to publish: unsafe ref name '$REF_NAME'" >&2
@@ -136,14 +138,28 @@ jobs:
           # Reset-and-reapply retry loop: on a rejected push, hard-reset to the
           # latest docs branch and re-copy the generated JSON instead of rebasing,
           # so a concurrent write to the same file can never leave a conflict.
+          # A `.json.run` marker records which run last published each file; before
+          # every (re)apply we compare it against this run's id/attempt so a stale
+          # retry can never overwrite JSON already published by a newer run.
           for attempt in 1 2 3; do
+            marker="$PROJECT_NAME/$REF_NAME.json.run"
+            if [[ -f "$marker" ]]; then
+              read -r published_run published_attempt < "$marker" || true
+              if [[ "$published_run" =~ ^[0-9]+$ && "${published_attempt:-}" =~ ^[0-9]+$ ]] \
+                && { (( published_run > RUN_ID )) || { (( published_run == RUN_ID )) && (( published_attempt >= RUN_ATTEMPT )); }; }; then
+                echo "Skipping publish: run ${published_run} (attempt ${published_attempt}) already published newer docs for $PROJECT_NAME/$REF_NAME"
+                exit 0
+              fi
+            fi
             mkdir -p "$PROJECT_NAME"
             cp ../incoming/api.json "$PROJECT_NAME/$REF_NAME.json"
-            git add .
+            git add "$PROJECT_NAME/$REF_NAME.json"
             if git diff --cached --quiet; then
               echo "No changes to publish"
               exit 0
             fi
+            printf '%s %s\n' "$RUN_ID" "$RUN_ATTEMPT" > "$marker"
+            git add "$marker"
             git commit -m "docs($PROJECT_NAME): build for $REF_NAME ($SOURCE_SHA)"
             if git push; then
               exit 0

--- a/.github/workflows/reusable-documentation.yml
+++ b/.github/workflows/reusable-documentation.yml
@@ -112,22 +112,27 @@ jobs:
             echo "Refusing to publish: unsafe project name '$PROJECT_NAME'" >&2
             exit 1
           fi
-          mkdir -p "out/$PROJECT_NAME"
-          mv incoming/api.json "out/$PROJECT_NAME/$REF_NAME.json"
           cd out
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git add .
-          if git diff --cached --quiet; then
-            echo "No changes to publish"
-            exit 0
-          fi
-          git commit -m "docs($PROJECT_NAME): build for $REF_NAME ($SOURCE_SHA)"
+          # Reset-and-reapply retry loop: on a rejected push, hard-reset to the
+          # latest docs branch and re-copy the generated JSON instead of rebasing,
+          # so a concurrent write to the same file can never leave a conflict.
           for attempt in 1 2 3; do
+            mkdir -p "$PROJECT_NAME"
+            cp ../incoming/api.json "$PROJECT_NAME/$REF_NAME.json"
+            git add .
+            if git diff --cached --quiet; then
+              echo "No changes to publish"
+              exit 0
+            fi
+            git commit -m "docs($PROJECT_NAME): build for $REF_NAME ($SOURCE_SHA)"
             if git push; then
               exit 0
             fi
-            echo "Push rejected (attempt ${attempt}), rebasing onto latest docs branch"
-            git pull --rebase origin docs
+            echo "Push rejected (attempt ${attempt}), resetting onto latest docs branch"
+            git fetch origin docs
+            git reset --hard origin/docs
           done
-          git push
+          echo "Failed to publish docs after 3 attempts" >&2
+          exit 1

--- a/.github/workflows/reusable-documentation.yml
+++ b/.github/workflows/reusable-documentation.yml
@@ -83,9 +83,14 @@ jobs:
         # Sanitization is many-to-one (`feature/new-docs` and `feature-new-docs` both
         # map to `feature-new-docs`), so when it changed the name, append a short
         # hash of the original ref to keep distinct refs from overwriting each other.
+        # The `-<8 hex>` tail is a reserved discriminator: a literal ref that already
+        # ends in that pattern (e.g. `feature-new-docs-d927eadd`, which would collide
+        # with the hashed form of `feature/new-docs`) also gets a hash appended, so
+        # suffixed and unsuffixed names can never collide and the mapping stays
+        # injective while clean refs like `main` keep their flat names.
         run: |
           safe="${GITHUB_REF_NAME//[^A-Za-z0-9._-]/-}"
-          if [[ "$safe" != "$GITHUB_REF_NAME" ]]; then
+          if [[ "$safe" != "$GITHUB_REF_NAME" || "$safe" =~ -[0-9a-f]{8}$ ]]; then
             safe="${safe}-$(printf '%s' "$GITHUB_REF_NAME" | sha256sum | cut -c1-8)"
           fi
           echo "name=$safe" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/reusable-documentation.yml
+++ b/.github/workflows/reusable-documentation.yml
@@ -74,8 +74,16 @@ jobs:
       - name: Resolve ref name
         id: ref
         # Allowlist filename characters (slashes in e.g. `feature/new-docs` and any
-        # shell metacharacters become `-`) so the ref maps to a safe, flat file name
-        run: echo "name=${GITHUB_REF_NAME//[^A-Za-z0-9._-]/-}" >> "$GITHUB_OUTPUT"
+        # shell metacharacters become `-`) so the ref maps to a safe, flat file name.
+        # Sanitization is many-to-one (`feature/new-docs` and `feature-new-docs` both
+        # map to `feature-new-docs`), so when it changed the name, append a short
+        # hash of the original ref to keep distinct refs from overwriting each other.
+        run: |
+          safe="${GITHUB_REF_NAME//[^A-Za-z0-9._-]/-}"
+          if [[ "$safe" != "$GITHUB_REF_NAME" ]]; then
+            safe="${safe}-$(printf '%s' "$GITHUB_REF_NAME" | sha256sum | cut -c1-8)"
+          fi
+          echo "name=$safe" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/reusable-documentation.yml
+++ b/.github/workflows/reusable-documentation.yml
@@ -77,6 +77,11 @@ jobs:
     name: Publish to docs branch
     needs: docgen
     runs-on: ${{ inputs.operating-system }}
+    # Serializes uploads from the same caller repo. Races with other repos
+    # pushing to the shared docs branch are handled by the rebase+retry below.
+    concurrency:
+      group: docs-upload-${{ inputs.docs-repository }}
+      cancel-in-progress: false
     steps:
       - name: Checkout docs branch
         uses: actions/checkout@v6
@@ -105,4 +110,11 @@ jobs:
             exit 0
           fi
           git commit -m "docs(${{ inputs.project-name }}): build for ${{ needs.docgen.outputs.ref-name }} (${{ github.sha }})"
+          for attempt in 1 2 3; do
+            if git push; then
+              exit 0
+            fi
+            echo "Push rejected (attempt ${attempt}), rebasing onto latest docs branch"
+            git pull --rebase origin docs
+          done
           git push

--- a/.github/workflows/reusable-documentation.yml
+++ b/.github/workflows/reusable-documentation.yml
@@ -40,6 +40,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          # Some callers (e.g. stars-components) aggregate sibling repos as
+          # submodules that are part of the pnpm workspace and docgen input.
+          submodules: recursive
 
       - name: Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4

--- a/.github/workflows/reusable-documentation.yml
+++ b/.github/workflows/reusable-documentation.yml
@@ -123,6 +123,7 @@ jobs:
           SOURCE_SHA: ${{ github.sha }}
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUN_REPOSITORY: ${{ github.repository }}
         run: |
           if [[ ! "$REF_NAME" =~ ^[A-Za-z0-9._-]+$ ]]; then
             echo "Refusing to publish: unsafe ref name '$REF_NAME'" >&2
@@ -138,14 +139,19 @@ jobs:
           # Reset-and-reapply retry loop: on a rejected push, hard-reset to the
           # latest docs branch and re-copy the generated JSON instead of rebasing,
           # so a concurrent write to the same file can never leave a conflict.
-          # A `.json.run` marker records which run last published each file; before
-          # every (re)apply we compare it against this run's id/attempt so a stale
-          # retry can never overwrite JSON already published by a newer run.
+          # A `.json.run` marker records which repo+run last published each file;
+          # before every (re)apply we compare it against this run's id/attempt so a
+          # stale retry can never overwrite JSON already published by a newer run.
+          # Run ids are only guaranteed unique within one repository, so the skip
+          # only applies when the marker was written by the same repository; a
+          # different repo publishing to the same path falls through to
+          # last-writer-wins rather than being blocked by an incomparable id.
           for attempt in 1 2 3; do
             marker="$PROJECT_NAME/$REF_NAME.json.run"
             if [[ -f "$marker" ]]; then
-              read -r published_run published_attempt < "$marker" || true
-              if [[ "$published_run" =~ ^[0-9]+$ && "${published_attempt:-}" =~ ^[0-9]+$ ]] \
+              read -r published_repo published_run published_attempt < "$marker" || true
+              if [[ "$published_repo" == "$RUN_REPOSITORY" \
+                && "$published_run" =~ ^[0-9]+$ && "${published_attempt:-}" =~ ^[0-9]+$ ]] \
                 && { (( published_run > RUN_ID )) || { (( published_run == RUN_ID )) && (( published_attempt >= RUN_ATTEMPT )); }; }; then
                 echo "Skipping publish: run ${published_run} (attempt ${published_attempt}) already published newer docs for $PROJECT_NAME/$REF_NAME"
                 exit 0
@@ -158,7 +164,7 @@ jobs:
               echo "No changes to publish"
               exit 0
             fi
-            printf '%s %s\n' "$RUN_ID" "$RUN_ATTEMPT" > "$marker"
+            printf '%s %s %s\n' "$RUN_REPOSITORY" "$RUN_ID" "$RUN_ATTEMPT" > "$marker"
             git add "$marker"
             git commit -m "docs($PROJECT_NAME): build for $REF_NAME ($SOURCE_SHA)"
             if git push; then

--- a/.github/workflows/reusable-documentation.yml
+++ b/.github/workflows/reusable-documentation.yml
@@ -40,6 +40,11 @@ jobs:
   docgen:
     name: Generate API JSON
     runs-on: ${{ inputs.operating-system }}
+    # `operating-system` may select a Windows runner, whose default shell is
+    # PowerShell; every run step here uses Bash syntax, so pin the shell.
+    defaults:
+      run:
+        shell: bash
     outputs:
       ref-name: ${{ steps.ref.outputs.name }}
     steps:
@@ -96,6 +101,10 @@ jobs:
     name: Publish to docs branch
     needs: docgen
     runs-on: ${{ inputs.operating-system }}
+    # Same as docgen: the publish script is Bash, so pin the shell for Windows runners.
+    defaults:
+      run:
+        shell: bash
     # Serializes uploads from the same caller repo. Races with other repos
     # pushing to the shared docs branch are handled by the rebase+retry below.
     concurrency:

--- a/.github/workflows/reusable-documentation.yml
+++ b/.github/workflows/reusable-documentation.yml
@@ -108,6 +108,10 @@ jobs:
             echo "Refusing to publish: unsafe ref name '$REF_NAME'" >&2
             exit 1
           fi
+          if [[ ! "$PROJECT_NAME" =~ ^[A-Za-z0-9._-]+$ || "$PROJECT_NAME" == "." || "$PROJECT_NAME" == ".." ]]; then
+            echo "Refusing to publish: unsafe project name '$PROJECT_NAME'" >&2
+            exit 1
+          fi
           mkdir -p "out/$PROJECT_NAME"
           mv incoming/api.json "out/$PROJECT_NAME/$REF_NAME.json"
           cd out

--- a/.github/workflows/reusable-documentation.yml
+++ b/.github/workflows/reusable-documentation.yml
@@ -1,0 +1,107 @@
+name: documentation
+
+on:
+  workflow_call:
+    inputs:
+      project-name:
+        description: Folder name under the docs branch this project's JSON is published to
+        required: true
+        type: string
+      docgen-command:
+        description: Shell command that produces `docs-output/api.json` (run from the repo root, after install+build)
+        required: true
+        type: string
+      docs-repository:
+        description: The `owner/repo` whose `docs` branch aggregates every project's API JSON
+        required: false
+        default: wolfstar-project/stars-components
+        type: string
+      node-version:
+        description: Version spec of Node.js to use
+        required: false
+        default: '24'
+        type: string
+      operating-system:
+        description: The operating system to use (default `ubuntu-latest`)
+        required: false
+        default: ubuntu-latest
+        type: string
+    secrets:
+      WOLFSTAR_TOKEN:
+        description: Token with push access to `docs-repository`'s `docs` branch
+        required: true
+
+jobs:
+  docgen:
+    name: Generate API JSON
+    runs-on: ${{ inputs.operating-system }}
+    outputs:
+      ref-name: ${{ steps.ref.outputs.name }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Generate API JSON
+        run: |
+          mkdir -p docs-output
+          ${{ inputs.docgen-command }}
+
+      - name: Resolve ref name
+        id: ref
+        run: echo "name=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-json-${{ inputs.project-name }}
+          path: docs-output/api.json
+          retention-days: 1
+
+  upload:
+    name: Publish to docs branch
+    needs: docgen
+    runs-on: ${{ inputs.operating-system }}
+    steps:
+      - name: Checkout docs branch
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.docs-repository }}
+          ref: docs
+          path: out
+          token: ${{ secrets.WOLFSTAR_TOKEN }}
+
+      - name: Download JSON artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: docs-json-${{ inputs.project-name }}
+          path: incoming
+
+      - name: Move & commit
+        run: |
+          mkdir -p "out/${{ inputs.project-name }}"
+          mv incoming/api.json "out/${{ inputs.project-name }}/${{ needs.docgen.outputs.ref-name }}.json"
+          cd out
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add .
+          if git diff --cached --quiet; then
+            echo "No changes to publish"
+            exit 0
+          fi
+          git commit -m "docs(${{ inputs.project-name }}): build for ${{ needs.docgen.outputs.ref-name }} (${{ github.sha }})"
+          git push

--- a/.github/workflows/reusable-documentation.yml
+++ b/.github/workflows/reusable-documentation.yml
@@ -139,39 +139,46 @@ jobs:
           # Reset-and-reapply retry loop: on a rejected push, hard-reset to the
           # latest docs branch and re-copy the generated JSON instead of rebasing,
           # so a concurrent write to the same file can never leave a conflict.
-          # A `.json.run` marker records which repo+run last published each file
-          # and when that publish began; before every (re)apply we compare it
-          # against this run so a stale retry can never overwrite JSON already
-          # published by a newer run. Run ids are only comparable within one
-          # repository, so same-repo ordering uses run id + attempt, while a
-          # marker from a different repository (only possible when two callers
-          # misconfigure the same project-name) is ordered by publish start time.
-          publish_started_at=$(date -u +%s)
+          # A `.json.run` marker records which repo+run last published each file;
+          # before every (re)apply we compare it against this run so a stale retry
+          # can never overwrite JSON already published by a newer run. Run ids are
+          # only comparable within one repository, so same-repo ordering uses run
+          # id + attempt, while a marker from a different repository (only possible
+          # when two callers misconfigure the same project-name) is ordered by a
+          # publication token: zero-padded 10-digit publish start seconds, then
+          # repository, run id, and attempt as deterministic tie-breakers, compared
+          # as C-locale strings so equal-second publishes still have a total,
+          # collision-free order that every competing run resolves identically
+          # (the padding matches raw epoch seconds, so markers written by the
+          # previous seconds-only format keep comparing correctly). The marker is
+          # (re)written even when the generated JSON matches the current document,
+          # so an accepted no-op publish still leaves recency evidence that blocks
+          # older in-flight runs from overwriting it later.
+          export LC_ALL=C
+          publish_token="$(printf '%010d' "$(date -u +%s)")-${RUN_REPOSITORY}-${RUN_ID}-${RUN_ATTEMPT}"
           for attempt in 1 2 3; do
             marker="$PROJECT_NAME/$REF_NAME.json.run"
             if [[ -f "$marker" ]]; then
-              read -r published_repo published_run published_attempt published_at < "$marker" || true
+              read -r published_repo published_run published_attempt published_token < "$marker" || true
               if [[ "$published_repo" == "$RUN_REPOSITORY" \
                 && "$published_run" =~ ^[0-9]+$ && "${published_attempt:-}" =~ ^[0-9]+$ ]] \
                 && { (( published_run > RUN_ID )) || { (( published_run == RUN_ID )) && (( published_attempt >= RUN_ATTEMPT )); }; }; then
                 echo "Skipping publish: run ${published_run} (attempt ${published_attempt}) already published newer docs for $PROJECT_NAME/$REF_NAME"
                 exit 0
               fi
-              if [[ "$published_repo" != "$RUN_REPOSITORY" && "${published_at:-}" =~ ^[0-9]+$ ]] \
-                && (( published_at > publish_started_at )); then
-                echo "Skipping publish: $published_repo began publishing $PROJECT_NAME/$REF_NAME more recently"
+              if [[ "$published_repo" != "$RUN_REPOSITORY" && "${published_token:-}" > "$publish_token" ]]; then
+                echo "Skipping publish: $published_repo published $PROJECT_NAME/$REF_NAME with a newer publication token"
                 exit 0
               fi
             fi
             mkdir -p "$PROJECT_NAME"
             cp ../incoming/api.json "$PROJECT_NAME/$REF_NAME.json"
-            git add "$PROJECT_NAME/$REF_NAME.json"
+            printf '%s %s %s %s\n' "$RUN_REPOSITORY" "$RUN_ID" "$RUN_ATTEMPT" "$publish_token" > "$marker"
+            git add "$PROJECT_NAME/$REF_NAME.json" "$marker"
             if git diff --cached --quiet; then
               echo "No changes to publish"
               exit 0
             fi
-            printf '%s %s %s %s\n' "$RUN_REPOSITORY" "$RUN_ID" "$RUN_ATTEMPT" "$publish_started_at" > "$marker"
-            git add "$marker"
             git commit -m "docs($PROJECT_NAME): build for $REF_NAME ($SOURCE_SHA)"
             if git push; then
               exit 0

--- a/.github/workflows/reusable-documentation.yml
+++ b/.github/workflows/reusable-documentation.yml
@@ -11,6 +11,11 @@ on:
         description: Shell command that produces `docs-output/api.json` (run from the repo root, after install+build)
         required: true
         type: string
+      build-command:
+        description: Shell command that builds the packages before docgen (set to an empty string to skip)
+        required: false
+        default: pnpm build
+        type: string
       docs-repository:
         description: The `owner/repo` whose `docs` branch aggregates every project's API JSON
         required: false
@@ -58,7 +63,8 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build packages
-        run: pnpm build
+        if: inputs.build-command != ''
+        run: ${{ inputs.build-command }}
 
       - name: Generate API JSON
         run: |

--- a/.github/workflows/reusable-documentation.yml
+++ b/.github/workflows/reusable-documentation.yml
@@ -63,7 +63,8 @@ jobs:
 
       - name: Resolve ref name
         id: ref
-        run: echo "name=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+        # Replace slashes (e.g. `feature/new-docs`) so the ref maps to a flat file name
+        run: echo "name=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/reusable-documentation.yml
+++ b/.github/workflows/reusable-documentation.yml
@@ -39,13 +39,13 @@ jobs:
       ref-name: ${{ steps.ref.outputs.name }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ inputs.node-version }}
           cache: pnpm
@@ -63,11 +63,12 @@ jobs:
 
       - name: Resolve ref name
         id: ref
-        # Replace slashes (e.g. `feature/new-docs`) so the ref maps to a flat file name
-        run: echo "name=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
+        # Allowlist filename characters (slashes in e.g. `feature/new-docs` and any
+        # shell metacharacters become `-`) so the ref maps to a safe, flat file name
+        run: echo "name=${GITHUB_REF_NAME//[^A-Za-z0-9._-]/-}" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: docs-json-${{ inputs.project-name }}
           path: docs-output/api.json
@@ -84,7 +85,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout docs branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           repository: ${{ inputs.docs-repository }}
           ref: docs
@@ -92,15 +93,23 @@ jobs:
           token: ${{ secrets.WOLFSTAR_TOKEN }}
 
       - name: Download JSON artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: docs-json-${{ inputs.project-name }}
           path: incoming
 
       - name: Move & commit
+        env:
+          PROJECT_NAME: ${{ inputs.project-name }}
+          REF_NAME: ${{ needs.docgen.outputs.ref-name }}
+          SOURCE_SHA: ${{ github.sha }}
         run: |
-          mkdir -p "out/${{ inputs.project-name }}"
-          mv incoming/api.json "out/${{ inputs.project-name }}/${{ needs.docgen.outputs.ref-name }}.json"
+          if [[ ! "$REF_NAME" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "Refusing to publish: unsafe ref name '$REF_NAME'" >&2
+            exit 1
+          fi
+          mkdir -p "out/$PROJECT_NAME"
+          mv incoming/api.json "out/$PROJECT_NAME/$REF_NAME.json"
           cd out
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
@@ -109,7 +118,7 @@ jobs:
             echo "No changes to publish"
             exit 0
           fi
-          git commit -m "docs(${{ inputs.project-name }}): build for ${{ needs.docgen.outputs.ref-name }} (${{ github.sha }})"
+          git commit -m "docs($PROJECT_NAME): build for $REF_NAME ($SOURCE_SHA)"
           for attempt in 1 2 3; do
             if git push; then
               exit 0

--- a/.github/workflows/reusable-documentation.yml
+++ b/.github/workflows/reusable-documentation.yml
@@ -139,21 +139,27 @@ jobs:
           # Reset-and-reapply retry loop: on a rejected push, hard-reset to the
           # latest docs branch and re-copy the generated JSON instead of rebasing,
           # so a concurrent write to the same file can never leave a conflict.
-          # A `.json.run` marker records which repo+run last published each file;
-          # before every (re)apply we compare it against this run's id/attempt so a
-          # stale retry can never overwrite JSON already published by a newer run.
-          # Run ids are only guaranteed unique within one repository, so the skip
-          # only applies when the marker was written by the same repository; a
-          # different repo publishing to the same path falls through to
-          # last-writer-wins rather than being blocked by an incomparable id.
+          # A `.json.run` marker records which repo+run last published each file
+          # and when that publish began; before every (re)apply we compare it
+          # against this run so a stale retry can never overwrite JSON already
+          # published by a newer run. Run ids are only comparable within one
+          # repository, so same-repo ordering uses run id + attempt, while a
+          # marker from a different repository (only possible when two callers
+          # misconfigure the same project-name) is ordered by publish start time.
+          publish_started_at=$(date -u +%s)
           for attempt in 1 2 3; do
             marker="$PROJECT_NAME/$REF_NAME.json.run"
             if [[ -f "$marker" ]]; then
-              read -r published_repo published_run published_attempt < "$marker" || true
+              read -r published_repo published_run published_attempt published_at < "$marker" || true
               if [[ "$published_repo" == "$RUN_REPOSITORY" \
                 && "$published_run" =~ ^[0-9]+$ && "${published_attempt:-}" =~ ^[0-9]+$ ]] \
                 && { (( published_run > RUN_ID )) || { (( published_run == RUN_ID )) && (( published_attempt >= RUN_ATTEMPT )); }; }; then
                 echo "Skipping publish: run ${published_run} (attempt ${published_attempt}) already published newer docs for $PROJECT_NAME/$REF_NAME"
+                exit 0
+              fi
+              if [[ "$published_repo" != "$RUN_REPOSITORY" && "${published_at:-}" =~ ^[0-9]+$ ]] \
+                && (( published_at > publish_started_at )); then
+                echo "Skipping publish: $published_repo began publishing $PROJECT_NAME/$REF_NAME more recently"
                 exit 0
               fi
             fi
@@ -164,7 +170,7 @@ jobs:
               echo "No changes to publish"
               exit 0
             fi
-            printf '%s %s %s\n' "$RUN_REPOSITORY" "$RUN_ID" "$RUN_ATTEMPT" > "$marker"
+            printf '%s %s %s %s\n' "$RUN_REPOSITORY" "$RUN_ID" "$RUN_ATTEMPT" "$publish_started_at" > "$marker"
             git add "$marker"
             git commit -m "docs($PROJECT_NAME): build for $REF_NAME ($SOURCE_SHA)"
             if git push; then


### PR DESCRIPTION
## Summary
- Adds `reusable-documentation.yml`, a `workflow_call` job (docgen + upload) that mirrors the pattern already used by `reusable-labelsync.yml`.
- Each caller repo supplies a `docgen-command` that produces `docs-output/api.json` (typedoc `--json` export); the workflow publishes it to `<docs-repository>`'s `docs` branch at `<project-name>/<ref>.json`, using the existing `WOLFSTAR_TOKEN` secret.
- Companion caller workflows added in `stars-components` and `plugins`.

This is the CI half of aggregating multiple monorepos' API docs on one site, modeled on how sapphiredev's `.github`/`website`/`docs` repos work together (docgen -> upload -> per-project versioned JSON in a shared branch).

## Test plan
- [ ] Merge, then confirm the `stars-components` and `plugins` caller workflows (once pinned to this commit) run green and publish JSON into `stars-components`'s `docs` branch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/.github/pr/42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 3/5</h3></summary>

</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex executed the isolated documentation retry harness to create isolated bare Git remotes and working clones.
- The pre-push hook published a concurrent remote update just before the stale run pushed, causing the first push to be rejected.
- With the marker logic enabled, a same-repository marker for run 200 caused run 100 to print Skipping publish, leaving LATEST\_ALPHA and BETA\_NEW intact.
- An independent-project case retained BETA\_NEW through reset and reapply while publishing alpha.
- Finally, the control execution with the harness-only stale guard disabled demonstrated the workflow prevented the failure: after the same rejected push and reset sequence, the stale retry replaced LATEST\_ALPHA with STALE\_ALPHA.

<a href="https://app.greptile.com/trex/runs/16816908/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (10): Last reviewed commit: ["fix: reserve the hash-suffix pattern so ..."](https://github.com/wolfstar-project/.github/commit/5edd6902baab406176d54c9040236a247240b5f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49131461)</sub>

<!-- /greptile_comment -->