### PR TITLE
chore(docs): point default docs-repository at wolfstar-project/docs

### DIFF
--- a/.github/workflows/reusable-documentation.yml
+++ b/.github/workflows/reusable-documentation.yml
@@ -19,7 +19,7 @@ on:
       docs-repository:
         description: The `owner/repo` whose `docs` branch aggregates every project's API JSON
         required: false
-        default: wolfstar-project/stars-components
+        default: wolfstar-project/docs
         type: string
       node-version:
         description: Version spec of Node.js to use


### PR DESCRIPTION
## Summary
- Migrates the aggregated TypeDoc API JSON store from stars-components' `docs` branch to a dedicated `wolfstar-project/docs` repo, mirroring the sapphiredev/docs pattern.
- `reusable-documentation.yml`'s `docs-repository` default now points at `wolfstar-project/docs`, which has already been seeded with the current aggregated content.

## Test plan
- [x] Confirm `wolfstar-project/docs` repo exists with `docs` branch containing the migrated JSON.
- [ ] After merge, verify a push in stars-components/plugins publishes to `wolfstar-project/docs` (not stars-components' own `docs` branch).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/.github/pr/43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the changed target by running authenticated GitHub REST requests against both the prior and new documentation repositories and performing a Git smart-HTTP branch lookup, which returned HTTP 200 for the repository and docs branch and resolved refs/heads/docs to a commit.
- Compared the changed target with the previous target and confirmed parity: both targets returned HTTP 200 for the repository and docs branch and the docs ref resolved to the same commit; no source code changes were made and the validation script and outputs were added as artifacts.

<a href="https://app.greptile.com/trex/runs/16898355/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(docs): point default docs-reposito..."](https://github.com/wolfstar-project/.github/commit/680524e4fad19228b5684c3b48ff6852110e6077) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49341904)</sub>

<!-- /greptile_comment -->