### PR TITLE
chore(renovate): use shared wolfstar-project preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,4 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["github>sapphiredev/.github:sapphire-renovate"]
+	"extends": ["github>wolfstar-project/.github:wolfstar-renovate"]
 }

--- a/wolfstar-renovate.json
+++ b/wolfstar-renovate.json
@@ -1,0 +1,31 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"description": "Shared Renovate config for wolfstar-project repositories, inspired by SapphireDev's and danielroe's presets",
+	"extends": ["config:recommended", "group:allNonMajor", ":maintainLockFilesWeekly", ":widenPeerDependencies"],
+	"labels": ["dependencies"],
+	"schedule": ["before 12pm on Sunday"],
+	"minimumReleaseAge": "3 days",
+	"cloneSubmodules": true,
+	"npm": {
+		"packageRules": [
+			{
+				"automerge": true,
+				"matchCurrentVersion": "/^0\\./",
+				"matchUpdateTypes": ["patch"],
+				"platformAutomerge": true
+			},
+			{
+				"automerge": true,
+				"matchCurrentVersion": ">=1.0.0",
+				"matchUpdateTypes": ["minor", "patch"],
+				"platformAutomerge": true
+			},
+			{ "enabled": false, "matchDepTypes": ["engines"] },
+			{ "enabled": false, "matchPackageNames": ["/typescript/"] },
+			{ "enabled": false, "matchPackageNames": ["/typedoc/"] },
+			{ "enabled": false, "matchPackageNames": ["/discord-api-types/"] }
+		],
+		"postUpdateOptions": ["yarnDedupeHighest", "pnpmDedupe"],
+		"rangeStrategy": "bump"
+	}
+}


### PR DESCRIPTION
## What

This introduces wolfstar-project's own shared Renovate preset, `wolfstar-renovate.json`, at the root of this `.github` repo. It is inspired by [sapphiredev/.github](https://github.com/sapphiredev/.github)'s `sapphire-renovate.json` and [danielroe/renovate](https://github.com/danielroe/renovate)'s `default.json`.

This repo's own `.github/renovate.json` is updated to extend the new shared preset (`github>wolfstar-project/.github:wolfstar-renovate`) instead of `github>sapphiredev/.github:sapphire-renovate`, so it now dogfoods the preset it publishes.

## Why

Other wolfstar-project repositories are being migrated off the external `sapphiredev/.github` Renovate config and onto this org's own shared preset, so wolfstar-project repos no longer depend on an external org's configuration for their dependency update policy.

## Important: merge order

Other repos' migration PRs reference the preset as `github>wolfstar-project/.github:wolfstar-renovate`. Renovate resolves shared presets from the **target repo's default branch**, not from open PRs — so **this PR must be merged first**, before any of the dependent repos' PRs that reference this preset are merged, or Renovate will fail to resolve the config in those repos.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/.github/pr/45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789318409&installation_model_id=425462&pr_number=45&repository=wolfstar-project%2F.github&return_to=https%3A%2F%2Fgithub.com%2Fwolfstar-project%2F.github%2Fpull%2F45&signature=912aff21c4fa72435f16e23b64caf4d495a57ad1e47fe055f7d2c181fd81a8c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge based on the exercised Renovate configuration behavior.

There are no final findings. The only reported defect was directly contradicted by Renovate validation and npm manager configuration resolution.

**Files Needing Attention:** No files require changes for the reviewed behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(renovate): extend shared wolfstar-..."](https://github.com/wolfstar-project/.github/commit/c873e958d60c025ab4c487f003f3a17e1e584c89) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53394578)</sub>

<!-- /greptile_comment -->